### PR TITLE
Use Nectary's Configuration to retrieve target SOLR endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,11 @@ composer update
 This will regenerate the class auto-loader which does dependency mapping and creates static load order in the vendor folder.
 
 
+# Configuration
+See `config.conf.example` for example configuration.
+
+For example,
+```
+SolrApiUrl=http://127.0.0.1:8983/solr/gios/select
+```
+specifies the SOLR endpoint URL.

--- a/config.conf.example
+++ b/config.conf.example
@@ -1,0 +1,1 @@
+SolrApiUrl=http://127.0.0.1:8983/solr/gios/select

--- a/src/providers/solr-search.php
+++ b/src/providers/solr-search.php
@@ -41,11 +41,8 @@ class SolrSearch implements Search {
       $this->queryBuilder = new SolrQueryBuilder();
     }
 
-    // TODO: Require $apiUrl param
     if ( $apiUrl ) {
       $this->apiUrl = $apiUrl;
-    } else {
-      $this->apiUrl = 'http://127.0.0.1:8983/solr/gios/select'; // TODO: get this url from a config file
     }
 
     if ( $httpGetCommand ) {

--- a/src/search-api/search-engine.php
+++ b/src/search-api/search-engine.php
@@ -4,6 +4,7 @@ namespace SearchApi;
 use SearchApi\Models as Models;
 use SearchApi\Providers as Providers;
 use SearchApi\Services\Search as Search;
+use Nectary\Configuration as Configuration;
 
 /**
  * Class SearchEngine - This is the main entry point into this application, it takes search requests and
@@ -13,10 +14,12 @@ class SearchEngine {
   private $search;
 
   public function __construct( Search $search = null ) {
+    Configuration::set_configuration_path( 'config.conf' );
     if ( $search ) {
       $this->search = $search;
     } else {
-      $this->search = new Providers\SolrSearch();
+      $apiPath = trim( Configuration::get_instance()->get( 'SolrApiUrl' ), '\r\n' );
+      $this->search = new Providers\SolrSearch( null, null, $apiPath );
     }
   }
 


### PR DESCRIPTION
Addresses https://github.com/gios-asu/search-api/issues/41

PR should:
- Retrieve URL for SOLR endpoint from `config.conf` in root project directory.
- Place a sample config file in project root.
