### PR TITLE
Ken's integration test for SolrSearch with test Solr server

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ install:
 
 before_script:
   - mkdir coverage
-  - printf "SolrApiUrl=http://127.0.0.1:8983/solr/gios/select\nStanfordNerPath=lib/stanford-ner-2015-04-20/" > config.conf
+  - printf "TestSolrApiUrl=http://jilliantessa.me:8983/solr/gios-dev/select\nStanfordNerPath=lib/stanford-ner-2015-04-20/\n" > config.conf
 
 script:
   - vendor/bin/phpunit # --coverage-clover /tmp/coverage/clover.xml

--- a/README.md
+++ b/README.md
@@ -47,8 +47,6 @@ This will regenerate the class auto-loader which does dependency mapping and cre
 # Configuration
 See `config.conf.example` for example configuration.
 
-For example,
-```
-SolrApiUrl=http://127.0.0.1:8983/solr/gios/select
-```
-specifies the SOLR endpoint URL.
+ * `SolrApiUrl=http://127.0.0.1:8983/solr/gios/select` specifies the SOLR endpoint URL.
+ * `TestSolrApiUrl=http://jilliantessa.me:8983/solr/gios-dev/select`  specifies the SOLR endpoint URL used in tests.
+ * `StanfordNerPath=lib/stanford-ner-2015-04-20/` specifies target path for Stanford's NER library.

--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ composer create-project wp-coding-standards/wpcs:dev-master --no-dev -n standard
 ```
 vendor/bin/phpunit
 ```
+Make sure to add this line to your `config.conf`:
+`TestSolrApiUrl=http://jilliantessa.me:8983/solr/gios-dev/select`
+This will be the url to the Solr server the test will use.
 
 ## To run the spec tests:
 ```

--- a/config.conf.example
+++ b/config.conf.example
@@ -1,2 +1,3 @@
 SolrApiUrl=http://127.0.0.1:8983/solr/gios/select
 StanfordNerPath=./lib/stanford-ner-2015-04-20/
+TestSolrApiUrl=http://jilliantessa.me:8983/solr/gios-dev/select

--- a/config.conf.example
+++ b/config.conf.example
@@ -1,1 +1,2 @@
-SolrApiUrl=http://127.0.0.1:8983/solr/gios/select
+SolrApiUrl=http://jilliantessa.me:8983/solr/gios-dev/select
+TestSolrApiUrl=http://jilliantessa.me:8983/solr/gios-dev/select

--- a/test/integration/solr-search-test.php
+++ b/test/integration/solr-search-test.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Solr Search integration test
+ */
+namespace SearchApi\Test\Unit;
+
+use SearchApi;
+use SearchApi\Providers\SolrSearch;
+use SearchApi\Models;
+
+use Nectary\Configuration as Configuration;
+
+/**
+ * SolrSearch_Integration_test - Integration test for SOLR search
+ */
+class SolrSearch_Integration_test extends \PHPUnit_Framework_TestCase {
+  private function get_solr_search() {
+    Configuration::set_configuration_path( 'config.conf' );
+    $apiPath = trim( Configuration::get_instance()->get( 'TestSolrApiUrl' ) );
+
+    return new SolrSearch( null, null, $apiPath );
+  }
+
+  private function create_searchterms_from_array( $keywords_as_string ) {
+    $search_terms = array();
+    foreach ( $keywords_as_string as &$word ) {
+      array_push( $search_terms, new Models\SearchTerm( $word, null, null, 1, true ) );
+    }
+    return $search_terms;
+  }
+
+  public function test_solr_returns_one_result_for_unique_keyword() {
+    $solr = $this->get_solr_search();
+
+    $user_words = array( 'reification' );
+    $search_terms = $this->create_searchterms_from_array( $user_words );
+
+    $results = $solr->query( $search_terms );
+
+    $this->assertTrue( count( $results ) === 1 );
+  }
+}

--- a/test/integration/solr-search-test.php
+++ b/test/integration/solr-search-test.php
@@ -39,4 +39,26 @@ class SolrSearch_Integration_test extends \PHPUnit_Framework_TestCase {
 
     $this->assertTrue( count( $results ) === 1 );
   }
+
+  public function test_solr_returns_no_result_for_nothing() {
+    $solr = $this->get_solr_search();
+
+    $user_words = array();
+    $search_terms = $this->create_searchterms_from_array( $user_words );
+
+    $results = $solr->query( $search_terms );
+
+    $this->assertTrue( count( $results ) === 0 );
+  }
+
+  public function test_solr_returns_multiple_results_for_common_words() {
+    $solr = $this->get_solr_search();
+
+    $user_words = array( 'arid', 'environment' );
+    $search_terms = $this->create_searchterms_from_array( $user_words );
+
+    $results = $solr->query( $search_terms );
+
+    $this->assertTrue( count( $results ) > 1 );
+  }
 }


### PR DESCRIPTION
Set of integration tests that verifies that `SolrSearch`'s query plays well with an actual Solr server.
- Test for:
  - `query` should return exactly one result for some keyword unique to exactly one document.
  - `query` should return no results for empty list of search terms.
  - `query` should return multiple results for keywords common to more than one document.
- New entry for `config.conf`, `TestSolrApiUrl`. Put the URL to your Solr test server here. `README.md` updated with missing info about config.
- Modify `travis.yml` so `config.conf` gets written to with the URL to our Solr test server. Jillian's server URL is hard-coded in the YAML file. Sorry :( Maybe we can pull this URL from environment variables? Can we set custom env vars in Travis outside the YAML file?
