### PR TITLE
Eric http get

### DIFF
--- a/src/commands/http-get.php
+++ b/src/commands/http-get.php
@@ -11,6 +11,7 @@ use SearchApi\Commands;
 class HttpGet implements Command {
   private $curl;
   private $url;
+  private $seconds = 120;
 
   function __construct() {
     // create curl resource
@@ -37,8 +38,22 @@ class HttpGet implements Command {
     $ch = $this->curl;
     curl_setopt( $ch, CURLOPT_URL, $this->url );
     curl_setopt( $ch, CURLOPT_RETURNTRANSFER, 1 );
+    curl_setopt($ch, CURLOPT_TIMEOUT, seconds );
     $response = curl_exec( $ch );
 
+    // checking if curl failed
+    if ( $response === false ) {
+      curl_fail( $ch );
+    }
+
     return $response;
+  }
+
+  /**
+   * Throw Exception - if curl fails, get infomation and throw an exception
+   */
+  function curl_fail( $ch ) {
+    $info = curl_getinfo( $ch );
+    throw new Exception( 'error occured during curl exec. Additioanl info: ' . var_export( $info ) );
   }
 }

--- a/src/commands/http-get.php
+++ b/src/commands/http-get.php
@@ -12,7 +12,7 @@ use Exception;
 class HttpGet implements Command {
   private $curl;
   private $url;
-  private $seconds = 120;
+  private $timeout_seconds = 120;
 
   function __construct() {
     // create curl resource
@@ -39,7 +39,7 @@ class HttpGet implements Command {
     $ch = $this->curl;
     curl_setopt( $ch, CURLOPT_URL, $this->url );
     curl_setopt( $ch, CURLOPT_RETURNTRANSFER, 1 );
-    curl_setopt( $ch, CURLOPT_TIMEOUT, $this->seconds );
+    curl_setopt( $ch, CURLOPT_TIMEOUT, $this->timeout_seconds );
     $response = curl_exec( $ch );
 
     // checking if curl failed

--- a/src/commands/http-get.php
+++ b/src/commands/http-get.php
@@ -2,6 +2,7 @@
 
 namespace SearchApi\Commands;
 use SearchApi\Commands;
+use Exception;
 
 /**
  * Command for making simple GET requests.
@@ -38,12 +39,12 @@ class HttpGet implements Command {
     $ch = $this->curl;
     curl_setopt( $ch, CURLOPT_URL, $this->url );
     curl_setopt( $ch, CURLOPT_RETURNTRANSFER, 1 );
-    curl_setopt($ch, CURLOPT_TIMEOUT, seconds );
+    curl_setopt( $ch, CURLOPT_TIMEOUT, $this->seconds );
     $response = curl_exec( $ch );
 
     // checking if curl failed
     if ( $response === false ) {
-      curl_fail( $ch );
+      $this->curl_fail( $ch );
     }
 
     return $response;
@@ -51,6 +52,8 @@ class HttpGet implements Command {
 
   /**
    * Throw Exception - if curl fails, get infomation and throw an exception
+   *
+   * @throws Exception - on bad curl execution: returns curl info
    */
   function curl_fail( $ch ) {
     $info = curl_getinfo( $ch );

--- a/src/commands/http-get.php
+++ b/src/commands/http-get.php
@@ -57,6 +57,7 @@ class HttpGet implements Command {
    */
   function curl_fail( $ch ) {
     $info = curl_getinfo( $ch );
-    throw new Exception( 'error occured during curl exec. Additioanl info: ' . var_export( $info ) );
+    $excep_string = "\n" . http_build_query( $info, '', "\n" );
+    throw new Exception( 'error occured during curl exec. Additioanl info: ' . $excep_string );
   }
 }

--- a/src/providers/solr-search.php
+++ b/src/providers/solr-search.php
@@ -94,7 +94,7 @@ class SolrSearch implements Search {
    */
   function query( $search_terms, $options = null ) {
     // This is just a placeholder
-    if ( $search_terms === null ) {
+    if ( $search_terms === null || empty( $search_terms ) ) {
       return null;
     }
 

--- a/test/spec/SearchApi/Providers/SolrSearchSpec.php
+++ b/test/spec/SearchApi/Providers/SolrSearchSpec.php
@@ -21,8 +21,8 @@ class SolrSearchSpec extends ObjectBehavior {
     $this->shouldHaveType( 'SearchApi\Providers\SolrSearch' );
   }
 
-  function it_should_call_query_builder( QueryBuilder $query_builder ) {
-    $this->beConstructedWith( $query_builder );
+  function it_should_call_query_builder( QueryBuilder $query_builder, Commands\HttpGet $http_get_command ) {
+    $this->beConstructedWith( $query_builder, $http_get_command );
 
     $query_builder->build( 'test', null )->shouldBeCalled();
 

--- a/test/unit/http-get-unit-test.php
+++ b/test/unit/http-get-unit-test.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Http-get Unit tests
+ */
+namespace SearchApi\Test\Unit;
+
+use SearchApi;
+
+/**
+ * Http-get Unit_Tests - Unit tests for the http (lower level functions)
+ */
+class Http_Get_Unit_Test extends \PHPUnit_Framework_TestCase {
+
+  public function test_that_the_class_HttpGet_is_defined() {
+    $this->assertTrue( class_exists( 'SearchApi\Commands\HttpGet' ) );
+  }
+
+  /**
+   * Test to check that httpget throws an exception on bad execute
+   *
+   * @expectedException Exception
+   * @expectedExceptionMessage error occured during curl exec. Additioanl info:
+   */
+  public function test_that_HttpGet_throws_exception_on_bad_website() {
+    $http_class = new SearchApi\Commands\HttpGet();
+    $http_class->setUrl( '' );
+    $http_class->execute();
+  }
+}

--- a/test/unit/http-get-unit-test.php
+++ b/test/unit/http-get-unit-test.php
@@ -16,14 +16,26 @@ class Http_Get_Unit_Test extends \PHPUnit_Framework_TestCase {
   }
 
   /**
-   * Test to check that httpget throws an exception on bad execute
+   * Test to check that httpget throws an exception on without a url
    *
    * @expectedException Exception
    * @expectedExceptionMessage error occured during curl exec. Additioanl info:
    */
-  public function test_that_HttpGet_throws_exception_on_bad_website() {
+  public function test_that_HttpGet_throws_exception_with_no_url() {
     $http_class = new SearchApi\Commands\HttpGet();
     $http_class->setUrl( '' );
     $http_class->execute();
+  }
+
+  /**
+   * Test to check that httpget throws an exception on with bad url
+   *
+   * @expectedException Exception
+   * @expectedExceptionMessage error occured during curl exec. Additioanl info:
+   */
+  public function test_that_HttpGet_throws_exception_with_bad_website() {
+  	$http_class = new SearchApi\Commands\HttpGet();
+  	$http_class->setUrl( 'BadWebSite' );
+  	$http_class->execute();
   }
 }

--- a/test/unit/http-get-unit-test.php
+++ b/test/unit/http-get-unit-test.php
@@ -36,15 +36,15 @@ class Http_Get_Unit_Test extends \PHPUnit_Framework_TestCase {
   public function test_that_http_get_throws_exception_with_bad_website() {
     $http_class = new SearchApi\Commands\HttpGet();
     $http_class->setUrl( 'BadWebSite!!^#$%' );
-    var_dump($http_class->execute());
+    $http_class->execute();
   }
 
   /**
    * Test to check that httpget execution on good url
    */
   public function test_that_http_get_executes_on_good_website() {
-  	$http_class = new SearchApi\Commands\HttpGet();
-  	$http_class->setUrl( 'google.com' );
-  	$this->assertNotFalse($http_class->execute());
+    $http_class = new SearchApi\Commands\HttpGet();
+    $http_class->setUrl( 'google.com' );
+    $this->assertNotFalse( $http_class->execute() );
   }
 }

--- a/test/unit/http-get-unit-test.php
+++ b/test/unit/http-get-unit-test.php
@@ -34,8 +34,8 @@ class Http_Get_Unit_Test extends \PHPUnit_Framework_TestCase {
    * @expectedExceptionMessage error occured during curl exec. Additioanl info:
    */
   public function test_that_HttpGet_throws_exception_with_bad_website() {
-  	$http_class = new SearchApi\Commands\HttpGet();
-  	$http_class->setUrl( 'BadWebSite' );
-  	$http_class->execute();
+    $http_class = new SearchApi\Commands\HttpGet();
+    $http_class->setUrl( 'BadWebSite' );
+    $http_class->execute();
   }
 }

--- a/test/unit/http-get-unit-test.php
+++ b/test/unit/http-get-unit-test.php
@@ -11,7 +11,7 @@ use SearchApi;
  */
 class Http_Get_Unit_Test extends \PHPUnit_Framework_TestCase {
 
-  public function test_that_the_class_HttpGet_is_defined() {
+  public function test_that_the_class_http_get_is_defined() {
     $this->assertTrue( class_exists( 'SearchApi\Commands\HttpGet' ) );
   }
 
@@ -21,7 +21,7 @@ class Http_Get_Unit_Test extends \PHPUnit_Framework_TestCase {
    * @expectedException Exception
    * @expectedExceptionMessage error occured during curl exec. Additioanl info:
    */
-  public function test_that_HttpGet_throws_exception_with_no_url() {
+  public function test_that_http_get_throws_exception_with_no_url() {
     $http_class = new SearchApi\Commands\HttpGet();
     $http_class->setUrl( '' );
     $http_class->execute();
@@ -33,7 +33,7 @@ class Http_Get_Unit_Test extends \PHPUnit_Framework_TestCase {
    * @expectedException Exception
    * @expectedExceptionMessage error occured during curl exec. Additioanl info:
    */
-  public function test_that_HttpGet_throws_exception_with_bad_website() {
+  public function test_that_http_get_throws_exception_with_bad_website() {
     $http_class = new SearchApi\Commands\HttpGet();
     $http_class->setUrl( 'BadWebSite' );
     $http_class->execute();

--- a/test/unit/http-get-unit-test.php
+++ b/test/unit/http-get-unit-test.php
@@ -35,7 +35,16 @@ class Http_Get_Unit_Test extends \PHPUnit_Framework_TestCase {
    */
   public function test_that_http_get_throws_exception_with_bad_website() {
     $http_class = new SearchApi\Commands\HttpGet();
-    $http_class->setUrl( 'BadWebSite' );
-    $http_class->execute();
+    $http_class->setUrl( 'BadWebSite!!^#$%' );
+    var_dump($http_class->execute());
+  }
+
+  /**
+   * Test to check that httpget execution on good url
+   */
+  public function test_that_http_get_executes_on_good_website() {
+  	$http_class = new SearchApi\Commands\HttpGet();
+  	$http_class->setUrl( 'google.com' );
+  	$this->assertNotFalse($http_class->execute());
   }
 }


### PR DESCRIPTION
Update http-get

```
-add timeout for curl calls that last longer than 2 mins.
-add check for failed curl call (returned false)
     -throws exception and returns information about the failed curl call
-add http get unit tests
        -add test to check that the http get is initalizable
        -add test to check for exception on bad curl call
               -checks that the exception message is about the curl call failure
```
