### PR TITLE
Set Java version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ php:
   # - hhvm
 
 before_install:
-  - sudo apt-get install -y openjdk-7-jre
+  - sudo apt-get install -y openjdk-8-jre
   - java -version
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,10 +17,13 @@ php:
   # - hhvm
 
 before_install:
+  # Install Java 8
   - sudo add-apt-repository -y ppa:webupd8team/java
   - sudo apt-get update
   - sudo apt-get install -y oracle-java8-installer
-  - export JAVA_HOME=/usr/lib/jvm/java-8-oracle
+  
+  # Set and check Java version
+  - sudo update-java-alternatives --set java-8-oracle
   - java -version
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ php:
 
 before_install:
   - sudo apt-get install -y openjdk-7-jre
+  - java -version
 
 install:
   - if [ ! -d "lib/stanford-ner-2015-04-20" ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: php
 
 cache:
+  apt: true
   directories:
     - vendor
     - lib
@@ -16,7 +17,10 @@ php:
   # - hhvm
 
 before_install:
-  - sudo apt-get install -y openjdk-8-jre
+  - sudo add-apt-repository -y ppa:webupd8team/java
+  - sudo apt-get update
+  - sudo apt-get install -y oracle-java8-installer
+  - export JAVA_HOME=/usr/lib/jvm/java-8-oracle
   - java -version
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,10 @@
 language: php
 
-sudo: false
-
 cache:
   directories:
     - vendor
     - lib
     - $HOME/.composer/cache
-    - $HOME/.linuxbrew
 
 php:
   - 5.5.9
@@ -19,15 +16,7 @@ php:
   # - hhvm
 
 before_install:
-  # BEGIN requisite commands for installing Java 8 (OpenJDK)
-  - if [ ! -d "$HOME/.linuxbrew/bin" ]; then
-      yes | ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/linuxbrew/go/install)";
-    fi
-  - export PATH="$HOME/.linuxbrew/bin:$PATH"
-  - export MANPATH="$HOME/.linuxbrew/share/man:$MANPATH"
-  - export INFOPATH="$HOME/.linuxbrew/share/info:$INFOPATH"
-  - brew install jdk
-  # END
+  - sudo apt-get install -y openjdk-7-jre
 
 install:
   - if [ ! -d "lib/stanford-ner-2015-04-20" ]; then


### PR DESCRIPTION
Fix for #93. 
- No longer uses containers. Boo.
- Installs Oracle's Java 8 JRE on Travis
- Sets Java version to `java-8-oracle`
- Caches `apt` packages 
